### PR TITLE
fix typo of 'twitter'

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -27,7 +27,7 @@
                 <a class="am-icon-btn am-icon-weibo" target="_blank" itemtype="url" href="<?php $this->options->socialWeibo(); ?>"></a>
             </li>
             <?php endif; ?>
-            <?php if ($this->options->socialTwiiter): ?>
+            <?php if ($this->options->socialTwitter): ?>
             <li>
                 <a class="am-icon-btn am-icon-twitter" target="_blank" itemtype="url" href="<?php $this->options->socialTwitter(); ?>"></a>
             </li>


### PR DESCRIPTION
 拼写错误导致首页sidebar的twitter图标不显示